### PR TITLE
added status filter para, to fetchPets only on home page

### DIFF
--- a/my-app/src/views/home/home.component.jsx
+++ b/my-app/src/views/home/home.component.jsx
@@ -108,7 +108,7 @@ const Home = () => {
 
   // Cambiar de página
   const handlePageChange = (pageNumber) => {
-    dispatch(fetchPets({ species, energyLevel, size }, pageNumber));
+    dispatch(fetchPets({ species, energyLevel, size, status: "available" }, pageNumber));
   };
 
   // Reiniciar filtros y limpiar localStorage


### PR DESCRIPTION
Agregué el param de filtro 'status' en la llamada al listado de mascotas desde el home para que se muestren únicamente las mascotas disponibles para adopción.